### PR TITLE
Support FreeNAS 9.3

### DIFF
--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -163,6 +163,10 @@ if [ -x "/usr/bin/perl5.16" ]; then
     PERL_516=/usr/bin/perl5.16
 elif [ -x "/usr/bin/perl5.16.3" ]; then
     PERL_516=/usr/bin/perl5.16.3
+elif [ -x "/usr/local/bin/perl5.16" ]; then
+    PERL_516=/usr/local/bin/perl5.16
+elif [ -x "/usr/local/bin/perl5.16.3" ]; then
+    PERL_516=/usr/local/bin/perl5.16.3
 fi
 
 if [ $PERL_516 ]; then

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -46,7 +46,7 @@ else
 fi
 
 if [ ! -x `which rsync` ]; then
-    echo "This script requires /usr/bin/rsync, please install it."
+    echo "This script requires rsync to be in your PATH, please install it."
     exit
 fi
 

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -45,7 +45,7 @@ else
     exit
 fi
 
-if [ ! -x /usr/bin/rsync ]; then
+if [ ! -x `which rsync` ]; then
     echo "This script requires /usr/bin/rsync, please install it."
     exit
 fi

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -1603,7 +1603,7 @@ function build_ffmpeg {
         FFOPTS="$FFOPTS --disable-mmx"
     fi
     # FreeBSD amd64 needs arch option
-    if [ $ARCH = "amd64-freebsd" ]; then
+    if [[ $ARCH = amd64-freebsd* ]]; then
 	FFOPTS="$FFOPTS --arch=x64"
     fi
     

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -17,7 +17,7 @@
 #   Under 10.7, builds for x86_64 Perl 5.12.3 (Lion does not support 32-bit CPUs)
 #   Under 10.9, builds for x86_64 Perl 5.16
 # FreeBSD 7.2 (Perl 5.8.9)
-# FreeBSD 8.2 (Perl 5.12.4)
+# FreeBSD 8.X,9.X (Perl 5.12.4)
 #
 # Perl 5.12.4/5.14.1 note:
 #   You should build 5.12.4 using perlbrew and the following command. GCC's stack protector must be disabled
@@ -1601,6 +1601,10 @@ function build_ffmpeg {
     # XXX test --arch options on Linux
     if [ $ARCH = "x86_64-linux-thread-multi" ]; then
         FFOPTS="$FFOPTS --disable-mmx"
+    fi
+    # FreeBSD amd64 needs arch option
+    if [ $ARCH = "amd64-freebsd" ]; then
+	FFOPTS="$FFOPTS --arch=x64"
     fi
     
     if [ $OS = "Darwin" ]; then


### PR DESCRIPTION
Stuff fixed:
- Correct FreeBSD $ARCH detection
- Fix ffmpeg build options on FreeBSD
- Support perl 5.16 being installed via ports
- Find rsync from $PATH rather than assume absolute location
